### PR TITLE
Update instructions - no hyphens in host name

### DIFF
--- a/docs/guide/install_software.md
+++ b/docs/guide/install_software.md
@@ -59,7 +59,7 @@ We can also setup the hostname so that your Pi easier to find once on the networ
 ping d2.local
 ```
 
-once it's booted. If there are many other Pi's on the network, then this will have problems. If you are on a Linux machine, or are able to edit the UUID partition, then you can edit the `/etc/hostname` and `/etc/hosts` files now to make finding your pi on the network easier after boot. Edit those to replace `raspberrypi` with a name of your choosing. Use all lower case, no special characters, no hyphens, yes underscores `_`. 
+once it's booted. If there are many other Pi's on the network, then this will have problems. If you are on a Linux machine, or are able to edit the UUID partition, then you can edit the `/etc/hostname` and `/etc/hosts` files now to make finding your pi on the network easier after boot. Edit those to replace `raspberrypi` with a name of your choosing. Use all lower case, no special characters, no hyphens, no underscores `_`. 
 
 ```
 sudo vi /media/userID/UUID/etc/hostname


### PR DESCRIPTION
Using underscore in the host name prevents you from pinging it via host name. Updating instructions to indicate no underscores.

According to RFC 1123, section 2.1 "Host Names and Numbers" host names are limited to just letters, digits, and hyphens.